### PR TITLE
Now uses attach instead of accepting specs straight away

### DIFF
--- a/src/main/kotlin/nl/devhaan/kotlinpoetdsl/Variable.kt
+++ b/src/main/kotlin/nl/devhaan/kotlinpoetdsl/Variable.kt
@@ -109,6 +109,5 @@ data class Variable(
         else -> toPropertySpec().toString()
     }.removeSuffix("\n")
 }
-
 fun PropertySpec.toVariable() = Variable(this)
 fun ParameterSpec.toVariable(propertyData: PropertyData? = null) = Variable(this, propertyData)

--- a/src/main/kotlin/nl/devhaan/kotlinpoetdsl/classes/ClassAcceptor.kt
+++ b/src/main/kotlin/nl/devhaan/kotlinpoetdsl/classes/ClassAcceptor.kt
@@ -34,8 +34,20 @@ interface ClassAcceptor : IAcceptor {
         it.typeName = this.asTypeName()
     }
 
-}
+    /**
+     * Adds Typespec keeping modifiers
+     */
+    fun TypeSpec.attachClazz() = this@ClassAcceptor.accept(this)
 
+
+    fun TypeSpec.attachClazz(editModifiers: ModifierEditorDSL.()->Set<KModifier>) {
+        val newModifiers = ModifierEditorDSL(this.modifiers).editModifiers()
+        this.buildUpon {
+            this@buildUpon.modifiers.clear()
+            this@buildUpon.modifiers.addAll(newModifiers)
+        }.attachClazz()
+    }
+}
 
 
 //functions are private, such that they don't popup in the DSL
@@ -98,14 +110,6 @@ private  fun ClassAcceptor.classBuilder() = ClassBuilder(
 )
 private fun ClassAcceptor.incompleteClassBuilder() =
         IncompleteClassBuilder(this, classBuilder().also(this::registerBuilder))
-
-fun ClassAcceptor.clazz(typeSpec: TypeSpec) = accept(typeSpec.let {
-    if (this is IAccessor<*>) {
-        it.buildUpon {
-            addModifiers(*this@clazz.modifiers)
-        }
-    } else it
-})
 
 
 fun ClassAcceptor.clazz(name: String, vararg variables: Variable, init: ClassBuilder.() -> Unit)

--- a/src/main/kotlin/nl/devhaan/kotlinpoetdsl/constructorBuilder/ConstructorAcceptor.kt
+++ b/src/main/kotlin/nl/devhaan/kotlinpoetdsl/constructorBuilder/ConstructorAcceptor.kt
@@ -2,10 +2,8 @@ package nl.devhaan.kotlinpoetdsl.constructorBuilder
 
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import nl.devhaan.kotlinpoetdsl.IAcceptor
-import nl.devhaan.kotlinpoetdsl.IAccessor
-import nl.devhaan.kotlinpoetdsl.PlainAccessor
-import nl.devhaan.kotlinpoetdsl.Variable
+import com.sun.xml.internal.bind.v2.runtime.reflect.opt.Const
+import nl.devhaan.kotlinpoetdsl.*
 import nl.devhaan.kotlinpoetdsl.codeblock.CodeBlockBuilder
 import nl.devhaan.kotlinpoetdsl.constructorBuilder.ConstructorAcceptor.IncompleteConstructorBuilder
 
@@ -17,6 +15,17 @@ interface ConstructorAcceptor : IAcceptor {
     fun Primary.constructor(vararg variable: Variable, init: CodeBlockBuilder.()->Unit = {})
             = constructorBuilder().buildPrimary(modifiers, variable, init)
 
+    fun FunSpec.attachConstructor() = accept(toConstructor())
+    fun FunSpec.attachConstructor(editModifiers: ModifierEditorDSL.() -> Set<KModifier>) = toConstructor().attachConstructor(editModifiers)
+
+    fun ConstructorSpec.attachConstructor() = accept(this)
+    fun ConstructorSpec.attachConstructor(editModifiers: ModifierEditorDSL.() -> Set<KModifier>){
+        buildUpon {
+            setModifiers(
+                    *ModifierEditorDSL(funSpec.modifiers).editModifiers().toTypedArray()
+            )
+        }.attachConstructor()
+    }
 }
 
 //----------------------------- only incomplete
@@ -56,13 +65,6 @@ fun ConstructorAcceptor.constructor(vararg variable: Variable, init: CodeBlockBu
 fun ConstructorAcceptor.constructor(vararg variable: Variable) = incompleteConstructorBuilder().unFinished {
     addVariables(*variable)
 }
-
-fun ConstructorAcceptor.constructor(funSpec: FunSpec) = accept(funSpec.toConstructor())
-fun ConstructorAcceptor.constructor(constructorSpec: ConstructorSpec) = accept(constructorSpec.let {
-    if (this is IAccessor<*>){
-        it.buildUpon { addModifiers(*this@constructor.modifiers) }
-    } else it
-})
 
 class Primary(val modifiers: Array<out KModifier>)
 

--- a/src/main/kotlin/nl/devhaan/kotlinpoetdsl/constructorBuilder/ConstructorSpec.kt
+++ b/src/main/kotlin/nl/devhaan/kotlinpoetdsl/constructorBuilder/ConstructorSpec.kt
@@ -66,6 +66,7 @@ class ConstructorSpec private constructor(
             variable.forEach { addParameter(it) }
         }
 
+        fun addStatement(format: String, vararg parts: Any) = withFun { addStatement(format, *parts) }
         fun addCode(codeBlock: CodeBlock) = withFun { addCode(codeBlock) }
         fun callThisConstructor(vararg args: String) = withFun {
             require(!isPrimary) {
@@ -87,6 +88,12 @@ class ConstructorSpec private constructor(
                 properties.takeIf { isPrimary }.orEmpty()
         )
 
+        fun setModifiers(vararg modifiers: KModifier) = withFun {
+            this@withFun.modifiers.let {
+                it.clear()
+                it.addAll(modifiers)
+            }
+        }
         fun addModifiers(vararg modifiers: KModifier) = withFun { addModifiers(*modifiers) }
     }
 

--- a/src/main/kotlin/nl/devhaan/kotlinpoetdsl/functions/FuncAcceptor.kt
+++ b/src/main/kotlin/nl/devhaan/kotlinpoetdsl/functions/FuncAcceptor.kt
@@ -33,6 +33,15 @@ interface FunctionAcceptor : IAcceptor {
             funcBuilder().buildExtensionFunction(this.typeName, name, variables, modifiers, buildScript)
 
     fun accept(func: FunSpec)
+
+    fun FunSpec.attachFunc() = accept(this)
+    fun FunSpec.attachFunc(editModifier: ModifierEditorDSL.()->Set<KModifier>){
+        val newModifiers = ModifierEditorDSL(this.modifiers).editModifier()
+        buildUpon {
+            modifiers.clear()
+            modifiers.addAll(newModifiers)
+        }.attachFunc()
+    }
 }
 
 private fun FunctionAcceptor.incompleteFuncBuilder() = IncompleteFunctionBuilder(this, funcBuilder().also(this::registerBuilder))
@@ -84,9 +93,3 @@ fun FunctionAcceptor.extension(typeName: TypeName) = Extension(
 )
 fun FunctionAcceptor.extension(clazz: KClass<*>) = extension(clazz.asTypeName())
 inline fun <reified T> FunctionAcceptor.extension() = extension(T::class.asTypeName())
-
-fun FunctionAcceptor.func(funSpec: FunSpec) = accept(funSpec.let {
-    if (this is IAccessor<*>) {
-        it.buildUpon { addModifiers(*this@func.modifiers) }
-    } else it
-})

--- a/src/main/kotlin/nl/devhaan/kotlinpoetdsl/properties/PropAcceptor.kt
+++ b/src/main/kotlin/nl/devhaan/kotlinpoetdsl/properties/PropAcceptor.kt
@@ -1,12 +1,19 @@
 package nl.devhaan.kotlinpoetdsl.properties
 
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
-import nl.devhaan.kotlinpoetdsl.IAccessor
-import nl.devhaan.kotlinpoetdsl.PlainAccessor
-import nl.devhaan.kotlinpoetdsl.Variable
+import nl.devhaan.kotlinpoetdsl.*
 
 interface PropAcceptor{
     fun accept(prop: PropertySpec)
+    fun PropertySpec.attachProp() = accept(this)
+    fun PropertySpec.attachProp(editorModifiers: ModifierEditorDSL.()->Set<KModifier>){
+        val newModifiers = ModifierEditorDSL(modifiers).editorModifiers()
+        buildUpon {
+            modifiers.clear()
+            modifiers.addAll(newModifiers)
+        }.attachProp()
+    }
 }
 
 fun PropAcceptor.propBuilder() = PropBuilder(
@@ -14,10 +21,3 @@ fun PropAcceptor.propBuilder() = PropBuilder(
         accept = ::accept
 )
 fun PropAcceptor.prop(variable: Variable, buildScript: PropBuilder.()->Unit={}) = propBuilder().buildProp(variable, buildScript)
-fun PropAcceptor.prop(propSpec: PropertySpec) = accept(propSpec.let {
-    if (this is IAccessor<*>){
-        it.buildUpon {
-            addModifiers(*this@prop.modifiers)
-        }
-    } else it
-})

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/clazz/ClassAcceptorTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/clazz/ClassAcceptorTest.kt
@@ -13,7 +13,6 @@ import nl.devhaan.kotlinpoetdsl.classes.clazz
 import nl.devhaan.kotlinpoetdsl.classes.createClass
 import nl.devhaan.kotlinpoetdsl.files.file
 import nl.devhaan.kotlinpoetdsl.functions.func
-import nl.devhaan.kotlinpoetdsl.internal
 import nl.devhaan.kotlinpoetdsl.open
 
 
@@ -27,7 +26,6 @@ import nl.devhaan.kotlinpoetdsl.open
 class ClassAcceptorTest : StringSpec({
     val zeroClass = TypeSpec.classBuilder("Clazz").build()
     val oneClass = TypeSpec.classBuilder("Clazz").addModifiers(KModifier.OPEN).build()
-    val twoClass = TypeSpec.classBuilder("Clazz").addModifiers(KModifier.INTERNAL, KModifier.OPEN).build()
 
     "abstract builder with abstract method"{
         createClass{
@@ -60,27 +58,11 @@ class ClassAcceptorTest : StringSpec({
                 .build()
     }
 
-    "file with initialized Modifier"{
+    "file with modifier"{
         file("", "HelloWorld") {
-            clazz(oneClass)
+            open.clazz("Clazz"){}
         } shouldBe FileSpec.builder("", "HelloWorld")
                 .addType(oneClass)
-                .build()
-    }
-
-    "file add modifier"{
-        file("", "HelloWorld") {
-            open.clazz(zeroClass)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addType(oneClass)
-                .build()
-    }
-
-    "file merge modifier"{
-        file("", "HelloWorld") {
-            internal.clazz(oneClass)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addType(twoClass)
                 .build()
     }
 
@@ -94,35 +76,16 @@ class ClassAcceptorTest : StringSpec({
                 .build()
     }
 
-    "interface with initialized modifier"{
+    "interface with modifier"{
         createInterface {
             interf("HelloWorld"){
-                clazz(oneClass)
+                open.clazz("Clazz"){}
             }
         } shouldBe TypeSpec.interfaceBuilder("HelloWorld")
                 .addType(oneClass)
                 .build()
     }
 
-    "interface add modifier"{
-        createInterface {
-            interf("HelloWorld"){
-                open.clazz(zeroClass)
-            }
-        } shouldBe TypeSpec.interfaceBuilder("HelloWorld")
-                .addType(oneClass)
-                .build()
-    }
-
-    "interface merge modifier"{
-        createInterface {
-            interf("HelloWorld"){
-                internal.clazz(oneClass)
-            }
-        } shouldBe TypeSpec.interfaceBuilder("HelloWorld")
-                .addType(twoClass)
-                .build()
-    }
     "class without modifier"{
         createClass{
             clazz("HelloWorld") {
@@ -133,33 +96,13 @@ class ClassAcceptorTest : StringSpec({
                 .build()
     }
 
-    "class with initialized Modifier"{
-        createClass {
+    "class with modifier"{
+        createClass{
             clazz("HelloWorld") {
-                clazz(oneClass)
+                open.clazz("Clazz"){}
             }
         } shouldBe TypeSpec.classBuilder("HelloWorld")
                 .addType(oneClass)
-                .build()
-    }
-
-    "class add modifier"{
-        createClass {
-            clazz("HelloWorld") {
-                open.clazz(zeroClass)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addType(oneClass)
-                .build()
-    }
-
-    "class merge modifier"{
-        createClass {
-            clazz("HelloWorld") {
-                internal.clazz(oneClass)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addType(twoClass)
                 .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/clazz/ClassInvocationTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/clazz/ClassInvocationTest.kt
@@ -4,13 +4,10 @@ import com.squareup.kotlinpoet.*
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
-import nl.devhaan.kotlinpoetdsl.S
+import nl.devhaan.kotlinpoetdsl.*
 import nl.devhaan.kotlinpoetdsl.classes.*
 import nl.devhaan.kotlinpoetdsl.files.file
 import nl.devhaan.kotlinpoetdsl.functions.func
-import nl.devhaan.kotlinpoetdsl.of
-import nl.devhaan.kotlinpoetdsl.valOf
-import nl.devhaan.kotlinpoetdsl.varOf
 import java.lang.IllegalArgumentException
 
 /**
@@ -265,5 +262,29 @@ class ClassInvocationTest : StringSpec({
                 }
             }
         }.message shouldBe "primary constructor is already set"
+    }
+
+    "class attachFunc direct"{
+        val clazz  = TypeSpec.classBuilder("Clazz")
+                .addModifiers(KModifier.PUBLIC)
+                .build()
+
+        file("", "TestFile"){
+            clazz.attachClazz()
+        } shouldBe FileSpec.builder("", "TestFile")
+                .addType(clazz)
+                .build()
+    }
+
+    "class attachFunc DSL"{
+        val clazz  = TypeSpec.classBuilder("Clazz")
+                .addModifiers(KModifier.PUBLIC)
+                .build()
+
+        file("", "TestFile"){
+            clazz.attachClazz{ existing + open }
+        } shouldBe FileSpec.builder("", "TestFile")
+                .addType(clazz.buildUpon { addModifiers(KModifier.OPEN) })
+                .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/constructor/ConstructorAcceptor.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/constructor/ConstructorAcceptor.kt
@@ -12,11 +12,11 @@ import nl.devhaan.kotlinpoetdsl.constructorBuilder.createConstructor
 import nl.devhaan.kotlinpoetdsl.constructorBuilder.constructor
 import nl.devhaan.kotlinpoetdsl.final
 import nl.devhaan.kotlinpoetdsl.private
+import nl.devhaan.kotlinpoetdsl.public
 
 class ConstructorAcceptor : StringSpec({
     val zeroConstr = ConstructorSpec.constructorBuilder(false).build()
     val oneConstr = ConstructorSpec.constructorBuilder(false).addModifiers(KModifier.PRIVATE).build()
-    val twoConstr = ConstructorSpec.constructorBuilder(false).addModifiers(KModifier.FINAL, KModifier.PRIVATE).build()
     "builder without modifier"{
         createConstructor {
             constructor{}
@@ -39,33 +39,13 @@ class ConstructorAcceptor : StringSpec({
                 .build()
     }
 
-    "class with initialized modifier"{
+    "class with modifier"{
         createClass {
             clazz("Clazz"){
-                constructor(oneConstr)
+                private.constructor()
             }
         } shouldBe TypeSpec.classBuilder("Clazz")
                 .addConstructor(oneConstr)
-                .build()
-    }
-
-    "class add modifier"{
-        createClass {
-            clazz("Clazz"){
-                private.constructor(zeroConstr)
-            }
-        } shouldBe TypeSpec.classBuilder("Clazz")
-                .addConstructor(oneConstr)
-                .build()
-    }
-
-    "class merge modifier"{
-        createClass {
-            clazz("Clazz"){
-                final.constructor(oneConstr)
-            }
-        } shouldBe TypeSpec.classBuilder("Clazz")
-                .addConstructor(twoConstr)
                 .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/constructor/ConstructorInvocation.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/constructor/ConstructorInvocation.kt
@@ -9,6 +9,9 @@ import nl.devhaan.kotlinpoetdsl.classes.clazz
 import nl.devhaan.kotlinpoetdsl.classes.extends
 import nl.devhaan.kotlinpoetdsl.constructorBuilder.*
 import nl.devhaan.kotlinpoetdsl.files.file
+import nl.devhaan.kotlinpoetdsl.functions.buildUpon
+import org.reflections.util.ConfigurationBuilder.build
+import java.lang.reflect.Type
 import java.sql.Types
 
 class ConstructorInvocation : StringSpec({
@@ -121,7 +124,7 @@ class ConstructorInvocation : StringSpec({
                 .toSecondary()
         createClass {
             clazz("Clazz"){
-                constructor(constructor)
+                constructor.attachConstructor()
             }
         } shouldBe TypeSpec.classBuilder("Clazz")
                 .addFunction(
@@ -236,5 +239,67 @@ class ConstructorInvocation : StringSpec({
                     .build()
         }
     }
+
+    "constructor - funSpec direct attachFunc" {
+        val consFun = FunSpec.constructorBuilder().addModifiers(KModifier.PROTECTED)
+                .addParameter("test".valOf<Int>().toParamSpec())
+                .addStatement("println(2)")
+                .build()
+
+        createClass {
+            clazz("Clazz"){
+                consFun.attachConstructor()
+            }
+        } shouldBe TypeSpec.classBuilder("Clazz")
+                .addFunction(consFun)
+                .build()
+    }
+
+    "constructor - funspec attachFunc DSL" {
+        val consFun = FunSpec.constructorBuilder().addModifiers(KModifier.PROTECTED)
+                .addParameter("test".valOf<Int>().toParamSpec())
+                .addStatement("println(2)")
+                .build()
+
+        createClass {
+            clazz("Clazz"){
+                consFun.attachConstructor { +protected }
+            }
+        } shouldBe TypeSpec.classBuilder("Clazz")
+                .addFunction(
+                        consFun.buildUpon { addModifiers(KModifier.PROTECTED) }
+                ).build()
+    }
+
+    "constructor - ConstructorSpec direct attachFunc"{
+        val consSpec = ConstructorSpec.constructorBuilder()
+                .addParameter("test".valOf<Int>())
+                .addStatement("println(2)")
+                .build()
+
+        createClass {
+            clazz("Clazz"){
+                consSpec.attachConstructor()
+            }
+        } shouldBe TypeSpec.classBuilder("Clazz")
+                .addConstructor(consSpec)
+                .build()
+    }
+
+    "constructor - ConstructorSpec attachFunc DSL" {
+        val consSpec = ConstructorSpec.constructorBuilder()
+                .addParameter("test".valOf<Int>())
+                .addStatement("println(2)")
+                .build()
+        createClass {
+            clazz("Clazz"){
+                consSpec.attachConstructor{ + protected}
+            }
+        } shouldBe TypeSpec.classBuilder("Clazz")
+                .addConstructor(
+                        consSpec.buildUpon { addModifiers(KModifier.PROTECTED) }
+                ).build()
+    }
+
 })
 

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/function/FunctionAcceptorTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/function/FunctionAcceptorTest.kt
@@ -12,6 +12,7 @@ import nl.devhaan.kotlinpoetdsl.files.file
 import nl.devhaan.kotlinpoetdsl.functions.createFun
 import nl.devhaan.kotlinpoetdsl.functions.func
 import nl.devhaan.kotlinpoetdsl.open
+import nl.devhaan.kotlinpoetdsl.private
 import nl.devhaan.kotlinpoetdsl.protected
 
 /**
@@ -29,12 +30,7 @@ class FunctionAcceptorTest : StringSpec({
 
     val oneFun = FunSpec.builder("func")
             .addStatement("println(%S)", "hi")
-            .addModifiers(KModifier.OPEN)
-            .build()
-
-    val twoFun = FunSpec.builder("func")
-            .addStatement("println(%S)", "hi")
-            .addModifiers(KModifier.PROTECTED, KModifier.OPEN)
+            .addModifiers(KModifier.PRIVATE)
             .build()
 
     "builder without modifier"{
@@ -47,7 +43,7 @@ class FunctionAcceptorTest : StringSpec({
 
     "builder with modifier"{
         createFun {
-            open.func("func") {
+            private.func("func") {
                 statement("println(%S)", "hi")
             }
         } shouldBe oneFun
@@ -64,30 +60,15 @@ class FunctionAcceptorTest : StringSpec({
                 .build()
     }
 
-    "file with initialized Modifier"{
+    "file with Modifier"{
         file("", "HelloWorld") {
-            func(oneFun)
+            private.func("func") {
+                statement("println(%S)", "hi")
+            }
         } shouldBe FileSpec.builder("", "HelloWorld")
                 .addFunction(oneFun)
                 .build()
     }
-
-    "file add modifier"{
-        file("", "HelloWorld") {
-            open.func(zeroFun)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addFunction(oneFun)
-                .build()
-    }
-
-    "file merge modifier"{
-        file("", "HelloWorld") {
-            protected.func(oneFun)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addFunction(twoFun)
-                .build()
-    }
-
 
     "class without modifier"{
         createClass {
@@ -101,33 +82,15 @@ class FunctionAcceptorTest : StringSpec({
                 .build()
     }
 
-    "class with initialized Modifier"{
+    "class with Modifier"{
         createClass {
             clazz("HelloWorld") {
-                func(oneFun)
+                private.func("func") {
+                    statement("println(%S)", "hi")
+                }
             }
         } shouldBe TypeSpec.classBuilder("HelloWorld")
                 .addFunction(oneFun)
-                .build()
-    }
-
-    "class add modifier"{
-        createClass {
-            clazz("HelloWorld") {
-                open.func(zeroFun)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addFunction(oneFun)
-                .build()
-    }
-
-    "class merge modifier"{
-        createClass {
-            clazz("HelloWorld") {
-                protected.func(oneFun)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addFunction(twoFun)
                 .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/function/FunctionInvocationTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/function/FunctionInvocationTest.kt
@@ -9,9 +9,8 @@ import io.kotlintest.specs.StringSpec
 import nl.devhaan.kotlinpoetdsl.abstract
 import nl.devhaan.kotlinpoetdsl.classes.createClass
 import nl.devhaan.kotlinpoetdsl.classes.clazz
-import nl.devhaan.kotlinpoetdsl.functions.extension
-import nl.devhaan.kotlinpoetdsl.functions.func
-import nl.devhaan.kotlinpoetdsl.functions.returns
+import nl.devhaan.kotlinpoetdsl.functions.*
+import nl.devhaan.kotlinpoetdsl.inline
 import nl.devhaan.kotlinpoetdsl.of
 import nl.devhaan.kotlinpoetdsl.private
 
@@ -208,5 +207,36 @@ class FunctionInvocationTest : StringSpec({
                         .addModifiers(KModifier.PRIVATE)
                         .build()
         ).build()
+    }
+
+    "function attachFunc direct"{
+        val funSpec = createFun {
+            private.extension(Int::class).func("addOne") returns Int::class{
+                statement("return this+1")
+            }
+        }
+
+        createClass {
+            clazz("TestClazz"){
+                funSpec.attachFunc()
+            }
+        } shouldBe TypeSpec.classBuilder("TestClazz")
+                .addFunction(funSpec)
+                .build()
+    }
+    "function attachFunc DSL"{
+        val funSpec = createFun {
+            private.extension(Int::class).func("addOne") returns Int::class{
+                statement("return this+1")
+            }
+        }
+
+        createClass {
+            clazz("TestClazz"){
+                funSpec.attachFunc{+inline}
+            }
+        } shouldBe TypeSpec.classBuilder("TestClazz")
+                .addFunction(funSpec.buildUpon { addModifiers(KModifier.INLINE) })
+                .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/interf/InterfaceAcceptorTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/interf/InterfaceAcceptorTest.kt
@@ -16,7 +16,7 @@ import nl.devhaan.kotlinpoetdsl.private
 class InterfaceAcceptorTest : StringSpec({
     val zeroInterface = TypeSpec.interfaceBuilder("Interf").build()
     val oneInterface = TypeSpec.interfaceBuilder("Interf").addModifiers(KModifier.PRIVATE).build()
-    val twoInterface = TypeSpec.interfaceBuilder("Interf").addModifiers(KModifier.OPEN, KModifier.PRIVATE).build()
+
     "builder without modifier"{
         createInterface{
             interf("Interf"){}
@@ -37,27 +37,11 @@ class InterfaceAcceptorTest : StringSpec({
                 .build()
     }
 
-    "file with initialized Modifier"{
+    "file with Modifier"{
         file("", "HelloWorld"){
-            interf(oneInterface)
+            private.interf("Interf")
         } shouldBe FileSpec.builder("", "HelloWorld")
                 .addType(oneInterface)
-                .build()
-    }
-
-    "file add modifier" {
-        file("", "HelloWorld") {
-            private.interf(zeroInterface)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addType(oneInterface)
-                .build()
-    }
-
-    "file merge modifier" {
-        file("", "HelloWorld") {
-            open.interf(oneInterface)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addType(twoInterface)
                 .build()
     }
 
@@ -70,33 +54,13 @@ class InterfaceAcceptorTest : StringSpec({
                 .addType(zeroInterface)
                 .build()
     }
-    "clazz with initialized modifier"{
+    "clazz with modifier"{
         createClass{
             clazz("HelloWorld"){
-                interf(oneInterface)
+                private.interf("Interf"){}
             }
         } shouldBe TypeSpec.classBuilder("HelloWorld")
                 .addType(oneInterface)
-                .build()
-    }
-
-    "class add modifier"{
-        createClass{
-            clazz("HelloWorld"){
-                private.interf(zeroInterface)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addType(oneInterface)
-                .build()
-    }
-
-    "class merge modifier"{
-        createClass{
-            clazz("HelloWorld"){
-                open.interf(oneInterface)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addType(twoInterface)
                 .build()
     }
 
@@ -110,33 +74,13 @@ class InterfaceAcceptorTest : StringSpec({
                 .build()
     }
 
-    "interface with initialized modifier"{
+    "interface with modifier"{
         createInterface {
             interf("HelloWorld"){
-                interf(oneInterface)
+                private.interf("Interf")
             }
         } shouldBe TypeSpec.interfaceBuilder("HelloWorld")
                 .addType(oneInterface)
-                .build()
-    }
-
-    "interface add modifier"{
-        createInterface {
-            interf("HelloWorld"){
-                private.interf(zeroInterface)
-            }
-        } shouldBe TypeSpec.interfaceBuilder("HelloWorld")
-                .addType(oneInterface)
-                .build()
-    }
-
-    "interface merge modifier"{
-        createInterface {
-            interf("HelloWorld"){
-                open.interf(oneInterface)
-            }
-        } shouldBe TypeSpec.interfaceBuilder("HelloWorld")
-                .addType(twoInterface)
                 .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/interf/InterfaceInvocationTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/interf/InterfaceInvocationTest.kt
@@ -5,8 +5,10 @@ import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 import nl.devhaan.kotlinpoetdsl.`interface`.implements
 import nl.devhaan.kotlinpoetdsl.`interface`.interf
+import nl.devhaan.kotlinpoetdsl.classes.buildUpon
 import nl.devhaan.kotlinpoetdsl.files.file
 import nl.devhaan.kotlinpoetdsl.functions.func
+import nl.devhaan.kotlinpoetdsl.open
 
 class InterfaceInvocationTest : StringSpec({
     "plain interface"{
@@ -94,5 +96,29 @@ class InterfaceInvocationTest : StringSpec({
                         FunSpec.builder("func").build()
                 ).build()
         ).build()
+    }
+
+    "interface attachFunc direct"{
+        val interf  = TypeSpec.interfaceBuilder("Interf")
+                .addModifiers(KModifier.PUBLIC)
+                .build()
+
+        file("", "TestFile"){
+            interf.attachClazz()
+        } shouldBe FileSpec.builder("", "TestFile")
+                .addType(interf)
+                .build()
+    }
+
+    "class attachFunc DSL"{
+        val interf  = TypeSpec.interfaceBuilder("Interf")
+                .addModifiers(KModifier.PUBLIC)
+                .build()
+
+        file("", "TestFile"){
+            interf.attachClazz{ existing + open }
+        } shouldBe FileSpec.builder("", "TestFile")
+                .addType(interf.buildUpon { addModifiers(KModifier.OPEN) })
+                .build()
     }
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/prop/PropAcceptorTest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/prop/PropAcceptorTest.kt
@@ -18,7 +18,6 @@ import nl.devhaan.kotlinpoetdsl.valOf
 class PropAcceptorTest : StringSpec({
     val zeroProp = PropertySpec.builder("prop", String::class).build()
     val oneProp = PropertySpec.builder("prop", String::class, KModifier.FINAL).build()
-    val twoProp = PropertySpec.builder("prop", String::class, KModifier.PUBLIC, KModifier.FINAL).build()
 
     "builder without modifier"{
         createProp {
@@ -40,27 +39,11 @@ class PropAcceptorTest : StringSpec({
                 .build()
     }
 
-    "file with initialized modifier"{
+    "file with modifier"{
         file("", "HelloWorld") {
-            prop(oneProp)
+            final.prop("prop" valOf String::class)
         } shouldBe FileSpec.builder("", "HelloWorld")
                 .addProperty(oneProp)
-                .build()
-    }
-
-    "file add modifier"{
-        file("", "HelloWorld") {
-            final.prop(zeroProp)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addProperty(oneProp)
-                .build()
-    }
-
-    "file merge modifier"{
-        file("", "HelloWorld") {
-            public.prop(oneProp)
-        } shouldBe FileSpec.builder("", "HelloWorld")
-                .addProperty(twoProp)
                 .build()
     }
 
@@ -74,34 +57,13 @@ class PropAcceptorTest : StringSpec({
                 .build()
     }
 
-    "class with initialized modifier"{
+    "class with modifier"{
         createClass {
             clazz("HelloWorld") {
-                prop(oneProp)
+                final.prop("prop" valOf String::class)
             }
         } shouldBe TypeSpec.classBuilder("HelloWorld")
                 .addProperty(oneProp)
                 .build()
     }
-
-    "class add modifier"{
-        createClass {
-            clazz("HelloWorld") {
-                final.prop(zeroProp)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addProperty(oneProp)
-                .build()
-    }
-
-    "class merge modifier"{
-        createClass {
-            clazz("HelloWorld") {
-                public.prop(oneProp)
-            }
-        } shouldBe TypeSpec.classBuilder("HelloWorld")
-                .addProperty(twoProp)
-                .build()
-    }
-
 })

--- a/src/test/kotlin/nl/devhaan/kotlinpoetdsl/prop/PropInvocationtest.kt
+++ b/src/test/kotlin/nl/devhaan/kotlinpoetdsl/prop/PropInvocationtest.kt
@@ -6,15 +6,14 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
+import nl.devhaan.kotlinpoetdsl.*
 import nl.devhaan.kotlinpoetdsl.files.file
 import nl.devhaan.kotlinpoetdsl.getters.getter
-import nl.devhaan.kotlinpoetdsl.inline
-import nl.devhaan.kotlinpoetdsl.private
+import nl.devhaan.kotlinpoetdsl.properties.buildUpon
+import nl.devhaan.kotlinpoetdsl.properties.createProp
 
 import nl.devhaan.kotlinpoetdsl.properties.prop
 import nl.devhaan.kotlinpoetdsl.setters.setter
-import nl.devhaan.kotlinpoetdsl.valOf
-import nl.devhaan.kotlinpoetdsl.varOf
 
 class PropInvocationtest : StringSpec({
     "var" {
@@ -130,6 +129,28 @@ class PropInvocationtest : StringSpec({
                 ).mutable().build()
         ).build()
     }
+    "prop attach direct"{
+        val prop = createProp {
+            private.prop("prop".valOf<Int>("3"))
+        }
 
+        file("", "HelloWorld"){
+            prop.attachProp()
+        } shouldBe FileSpec.builder("", "HelloWorld")
+                .addProperty(prop)
+                .build()
+    }
+
+    "prop attach DSL"{
+        val prop = createProp {
+            private.prop("prop".valOf<Int>("3"))
+        }
+
+        file("", "HelloWorld"){
+            prop.attachProp{+final}
+        } shouldBe FileSpec.builder("", "HelloWorld")
+                .addProperty(prop.buildUpon { addModifiers(KModifier.FINAL) })
+                .build()
+    }
 
 })


### PR DESCRIPTION
There were two sets of modifiers: The specs one and the DSL's one.
Because it wasn't clear how to treat them, it is changed to a clear way.

The old way of adding was just an extension function.
This means that the old way can be added by implementing the methods from own code.

closes #21